### PR TITLE
Feature/fix check qc

### DIFF
--- a/assets/checkqc_settings.yaml
+++ b/assets/checkqc_settings.yaml
@@ -31,7 +31,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Precision"]
     sample_cols: ["samples"]
     title: "PK_D_INDELs"
-  - filename: "^(?=.*truth_pairwise)(?=.*SNP).*$"
+  - filename: "(?=.*truth_pairwise)(?=.*SNP).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.98
@@ -39,7 +39,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Recall"]
     sample_cols: ["samples"]
     title: "PK_E_SNPs"
-  - filename: "^(?=.*truth_pairwise)(?=.*INDEL).*$"
+  - filename: "(?=.*truth_pairwise)(?=.*INDEL).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.90

--- a/assets/checkqc_settings.yaml
+++ b/assets/checkqc_settings.yaml
@@ -1,5 +1,5 @@
 metrics:
-  - filename: ".*truth.*SNP"
+  - filename: "(?=.*truth)(?!.*truth_pairwise)(?=.*SNP).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.98
@@ -7,7 +7,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Recall"]
     sample_cols: ["samples"]
     title: "PK_C_SNPs"
-  - filename: ".*truth.*INDEL"
+  - filename: "(?=.*truth)(?!.*truth_pairwise)(?=.*INDEL).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.90
@@ -15,7 +15,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Recall"]
     sample_cols: ["samples"]
     title: "PK_C_INDELs"
-  - filename: ".*truth.*SNP"
+  - filename: "(?=.*truth)(?!.*truth_pairwise)(?=.*SNP).*$"
     delim: ","
     qc_col: "METRIC.Precision"
     threshold: 0.98
@@ -23,7 +23,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Precision"]
     sample_cols: ["samples"]
     title: "PK_D_SNPs"
-  - filename: ".*truth.*INDEL"
+  - filename: "(?=.*truth)(?!.*truth_pairwise)(?=.*INDEL).*$"
     delim: ","
     qc_col: "METRIC.Precision"
     threshold: 0.85
@@ -31,7 +31,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Precision"]
     sample_cols: ["samples"]
     title: "PK_D_INDELs"
-  - filename: "(?:(?!truth).)*SNP.*$"
+  - filename: "^(?=.*truth_pairwise)(?=.*SNP).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.98
@@ -39,7 +39,7 @@ metrics:
     report_cols: ["sample_truth", "sample_query", "METRIC.Recall"]
     sample_cols: ["samples"]
     title: "PK_E_SNPs"
-  - filename: "(?:(?!truth).)*INDEL.*$"
+  - filename: "^(?=.*truth_pairwise)(?=.*INDEL).*$"
     delim: ","
     qc_col: "METRIC.Recall"
     threshold: 0.90

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -29,6 +29,16 @@ custom_data:
       qc_value_pk_d_indels:
         description: "Precision (fraction) INDELs"
         format: "{:,.4f}"
+      qc_status_pk_e_snps:
+        description: "Sensitivity pairwise SNP comparison (PASS or FAIL)"
+      qc_value_pk_e_snps:
+        description: "Sensitivity (fraction) SNPs"
+        format: "{:,.4f}"
+      qc_status_pk_e_indels:
+        description: "Sensitivity pairwise INDEL comparison (PASS or FAIL)"
+      qc_value_pk_e_indels:
+        description: "Sensitivity (fraction) INDELs"
+        format: "{:,.4f}"
 
   happy_all_snp:
     id: "happy_all_snp"


### PR DESCRIPTION
* fixed CheckQC/MultiQC for single (pk_c and pk_d only) and pairwise samples (pk_e only)


checkqc_settings.yaml: 
Example files used as input for checkQC  (note that CheckQC process will only parse *_all_csv files):
```
a) HG001_truth_U175754CFGIAB12878a_0020_INDEL_ALL.summary.csv
b) HG001_truth_U175754CFGIAB12878a_0020_SNP_ALL.summary.csv
c) HG001_truth_U175754CFGIAB12878_0415_INDEL_ALL.summary.csv
d) HG001_truth_U175754CFGIAB12878_0415_SNP_ALL.summary.csve
e) HG001_truth_pairwise_U175754CFGIAB12878_0415_U175754CFGIAB12878a_0020_INDEL_ALL.summary.csv
f) HG001_truth_pairwise_U175754CFGIAB12878_0415_U175754CFGIAB12878a_0020_SNP_ALL.summary.csv
```
* regex for checkQC was changed to include output of single sample analyses ('truth', examples files a, b, c, and d) and not for pairwise analysis (truth_pairwise, example files e and f) for PK_C_SNPs, PK_C_INDELs, PK_D_SNPs, and PK_D_INDELs.
* regex for PK_E_SNPs and PK_E_INDELs was changed to include pairwise analysis only (example files e and f) and not single sample analysis (example files a, b, c, and d).

multiqc_config.yaml
* Added columns for pk_e in MultiQC output (only Sensitivity/Recall needed)