### PR TITLE
Feature/fix_targetfiles

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -45,7 +45,7 @@ workflow {
             query: meta_query.id,
             truth: meta_truth.id
         ]
-        return [meta, query, truth, regions_bed, false_positives]
+        return [meta, query, truth, regions_bed, []]
     }
 
     // Empty channel for optional inputs, where meta val is required (often input tuples)
@@ -55,10 +55,10 @@ workflow {
     assembly_to_use = params[params.nist_version_to_use].assembly
     ch_fasta = Channel.fromPath("${params.assembly[assembly_to_use].ref_fasta}").map(createMetaWithIdName).first()
     ch_fasta_fai = Channel.fromPath("${params.assembly[assembly_to_use].ref_fai}").map(createMetaWithIdName).first()
-   
+    ch_false_positives_bed = Channel.fromPath("${params[params.nist_version_to_use].high_conf_bed}").map(createMetaWithIdName).first()
+
     // Reference bed files
     regions_bed = "${params.assembly[params[params.nist_version_to_use].assembly].exome_target_bed}"
-    false_positives = "${params[params.nist_version_to_use].high_conf_bed}"
 
     // GIAB reference file channels
     ch_giab_truth = Channel.fromPath("${params[params.nist_version_to_use].truth_vcf}")
@@ -129,11 +129,12 @@ workflow {
             && [meta_query.id, meta_truth.id] == [meta_query.id, meta_truth.id].sort()
         )
         lst_used.add("pairwise_" + meta_query.id + "_" + meta_truth.id)
-        return [meta, query, truth, regions_bed, false_positives]
+        return [meta, query, truth, regions_bed, []]
     }
 
     // Run HAPPY for all VCF compared to GIAB truth
-    HAPPY_HAPPY_single(ch_vcf_giab, ch_fasta, ch_fasta_fai, empty, empty, empty)
+    HAPPY_HAPPY_single(ch_vcf_giab, ch_fasta, ch_fasta_fai, ch_false_positives_bed, empty, empty)
+
 
     // Reheader Happy output VCF with reference genome .fai
     BCFTOOLS_REHEADER_SINGLE(
@@ -142,7 +143,7 @@ workflow {
     )
 
     // Retrieve true-positives from pairwise comparisons.
-    HAPPY_HAPPY_pairwise(ch_vcf_pairwise, ch_fasta, ch_fasta_fai, empty, empty, empty)
+    HAPPY_HAPPY_pairwise(ch_vcf_pairwise, ch_fasta, ch_fasta_fai, ch_false_positives_bed, empty, empty)
     ch_pairwise_vcf_index = HAPPY_HAPPY_pairwise.out.vcf
         .map(addTmpId)
         .join(HAPPY_HAPPY_pairwise.out.tbi.map(addTmpId), by: 0)
@@ -187,7 +188,7 @@ workflow {
     // Run HAPPY on pairwise true-positives against GIAB truth
     HAPPY_HAPPY_tp_giab(
         BCFTOOLS_ANNOTATE.out.vcf.combine(BCFTOOLS_NORM_GIAB.out.vcf).map(createHappyInput),
-        ch_fasta, ch_fasta_fai, empty, empty, empty
+        ch_fasta, ch_fasta_fai, ch_false_positives_bed, empty, empty
     )   
 
     // Reheader Happy pairwise VCF with reference genome .fai

--- a/main.nf
+++ b/main.nf
@@ -55,7 +55,7 @@ workflow {
     assembly_to_use = params[params.nist_version_to_use].assembly
     ch_fasta = Channel.fromPath("${params.assembly[assembly_to_use].ref_fasta}").map(createMetaWithIdName).first()
     ch_fasta_fai = Channel.fromPath("${params.assembly[assembly_to_use].ref_fai}").map(createMetaWithIdName).first()
-    ch_false_positives_bed = Channel.fromPath("${params[params.nist_version_to_use].high_conf_bed}").map(createMetaWithIdName).first()
+    ch_false_positives_bed = Channel.fromPath("${params[params.nist_version_to_use].false_positives_bed}").map(createMetaWithIdName).first()
 
     // Reference bed files
     regions_bed = "${params.assembly[params[params.nist_version_to_use].assembly].exome_target_bed}"

--- a/main.nf
+++ b/main.nf
@@ -45,7 +45,7 @@ workflow {
             query: meta_query.id,
             truth: meta_truth.id
         ]
-        return [meta, query, truth, regions_bed, targets_bed]
+        return [meta, query, truth, regions_bed, false_positives]
     }
 
     // Empty channel for optional inputs, where meta val is required (often input tuples)
@@ -57,8 +57,8 @@ workflow {
     ch_fasta_fai = Channel.fromPath("${params.assembly[assembly_to_use].ref_fai}").map(createMetaWithIdName).first()
    
     // Reference bed files
-    regions_bed = "${params[params.nist_version_to_use].high_conf_bed}"
-    targets_bed = "${params.assembly[params[params.nist_version_to_use].assembly].exome_target_bed}"
+    regions_bed = "${params.assembly[params[params.nist_version_to_use].assembly].exome_target_bed}"
+    false_positives = "${params[params.nist_version_to_use].high_conf_bed}"
 
     // GIAB reference file channels
     ch_giab_truth = Channel.fromPath("${params[params.nist_version_to_use].truth_vcf}")
@@ -129,7 +129,7 @@ workflow {
             && [meta_query.id, meta_truth.id] == [meta_query.id, meta_truth.id].sort()
         )
         lst_used.add("pairwise_" + meta_query.id + "_" + meta_truth.id)
-        return [meta, query, truth, regions_bed, targets_bed]
+        return [meta, query, truth, regions_bed, false_positives]
     }
 
     // Run HAPPY for all VCF compared to GIAB truth

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
             ref_fasta = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta"
             ref_fai = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
             rtg_index = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/rtgtools_3.12.1/Homo_sapiens.GRCh37.GATK.illumina.SDF/"
-            exome_target_bed = "/hpc/diaggen/software/production/Dx_tracks/Tracks/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank_flat.bed"
+            exome_target_bed = "/hpc/diaggen/software/production/Dx_tracks/Tracks/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank_collapsed.bed"
             primary_contigs= "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y"
         }
         grch38 {

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
             ref_fasta = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta"
             ref_fai = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
             rtg_index = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/rtgtools_3.12.1/Homo_sapiens.GRCh37.GATK.illumina.SDF/"
-            exome_target_bed = "/hpc/diaggen/software/production/Dx_tracks/Tracks/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank.bed"
+            exome_target_bed = "/hpc/diaggen/users/Martin/GIABEval_testMergeBED/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank_flat.bed"
             primary_contigs= "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y"
         }
         grch38 {
@@ -65,8 +65,7 @@ params {
         filepath = "/hpc/diaggen/data/databases/GIAB/NA12878_HG001/NISTv2.19/GRCh37/"
         truth_vcf = "${filepath}HG001_NISTIntegratedCalls_14datasets_131103_allcall_UGHapMerge_HetHomVarPASS_VQSRv2.19_2mindatasets_5minYesNoRatio_all_nouncert_excludesimplerep_excludesegdups_excludedecoy_excludeRepSeqSTRs_noCNVs_fixHeader.vcf.gz"
         truth_vcf_index = "${filepath}HG001_NISTIntegratedCalls_14datasets_131103_allcall_UGHapMerge_HetHomVarPASS_VQSRv2.19_2mindatasets_5minYesNoRatio_all_nouncert_excludesimplerep_excludesegdups_excludedecoy_excludeRepSeqSTRs_noCNVs_fixHeader.vcf.gz.tbi"
-        high_conf_bed = "${filepath}union13callableMQonlymerged_addcert_nouncert_excludesimplerep_excludesegdups_excludedecoy_excludeRepSeqSTRs_noCNVs_v2.19_2mindatasets_5minYesNoRatio.bed"
-        false_positives_bed = null
+        false_positives_bed = "${filepath}union13callableMQonlymerged_addcert_nouncert_excludesimplerep_excludesegdups_excludedecoy_excludeRepSeqSTRs_noCNVs_v2.19_2mindatasets_5minYesNoRatio.bed"
     }
 
     hg001_nist_v4_2_1_grch37 {
@@ -74,8 +73,7 @@ params {
         filepath = "/hpc/diaggen/data/databases/GIAB/NA12878_HG001/NISTv4.2.1/GRCh37/"
         truth_vcf = "${filepath}HG001_GRCh37_1_22_v4.2.1_benchmark.vcf.gz"
         truth_vcf_index = "${filepath}HG001_GRCh37_1_22_v4.2.1_benchmark.vcf.gz.tbi"
-        high_conf_bed = "${filepath}HG001_GRCh37_1_22_v4.2.1_benchmark.bed"
-        false_positives_bed = null
+        false_positives_bed = "${filepath}HG001_GRCh37_1_22_v4.2.1_benchmark.bed"
     }
 
     hg001_nist_v4_2_1_grch38 {
@@ -83,8 +81,7 @@ params {
         filepath = "/hpc/diaggen/data/databases/GIAB/NA12878_HG001/NISTv4.2.1/GRCh38/"
         truth_vcf = "${filepath}HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
         truth_vcf_index = "${filepath}HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi"
-        high_conf_bed = "${filepath}HG001_GRCh38_1_22_v4.2.1_benchmark.bed"
-        false_positives_bed = null
+        false_positives_bed = "${filepath}HG001_GRCh38_1_22_v4.2.1_benchmark.bed"
     }
 
     hg002_nist_v4_2_1_grch38 {
@@ -92,8 +89,7 @@ params {
         filepath = "/hpc/diaggen/data/databases/GIAB/HG002_NA24385_son/NISTv4.2.1/GRCh38/"
         truth_vcf = "${filepath}HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
         truth_vcf_index = "${filepath}HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi"
-        high_conf_bed = "${filepath}HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed"
-        false_positives_bed = null
+        false_positives_bed = "${filepath}HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed"
     }
 
     // QC settings

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
             ref_fasta = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta"
             ref_fai = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
             rtg_index = "/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/rtgtools_3.12.1/Homo_sapiens.GRCh37.GATK.illumina.SDF/"
-            exome_target_bed = "/hpc/diaggen/users/Martin/GIABEval_testMergeBED/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank_flat.bed"
+            exome_target_bed = "/hpc/diaggen/software/production/Dx_tracks/Tracks/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank_flat.bed"
             primary_contigs= "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y"
         }
         grch38 {


### PR DESCRIPTION
* Added Exome to region_bed and HighConfident to channel false_positives_bed. This essentially removes the -T option in hap.py and fixes a 'bug' in which INDEL are incorrecty filtered on start-pos only (and not on full overlap) 